### PR TITLE
fix: FileNotFoundError because repetitively read content

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -47,10 +47,11 @@ def main():
     win_user = os.path.expandvars('$HOMEPATH')
     wx_config = open(os.getenv("SystemDrive") + win_user + '\\AppData\\Roaming\\Tencent\\WeChat\\All Users\\config\\3ebffe94.ini')
 
-    if wx_config.read() == 'MyDocument:':
-        wx_path = shell.SHGetFolderPath(0, 5, None, 0)+"\\WeChat Files\\"+wxid+"\\Msg" # 如果目录在 文档 下
+    path = wx_config.read()
+    if path == 'MyDocument:':
+        wx_path = shell.SHGetFolderPath(0, 5, None, 0) + "\\WeChat Files\\" + wxid + "\\Msg"  # 如果目录在 文档 下
     else:
-        wx_path = wx_config.read() + "\\WeChat Files\\"+wxid+"\\Msg"
+        wx_path = path + "\\WeChat Files\\" + wxid + "\\Msg"
     dir_path = wx_path + "\\Multi"
 
     print("[+]微信号: "+wxprofile+" 工作路径: "+wx_path)


### PR DESCRIPTION
这里`wx_config.read()`函数调用了两次，导致如果跳到else分支则会发生以下错误：
`FileNotFoundError: [WinError 3] The system cannot find the path specified: '\\WeChat Files\\wxid_nkxce4xhrqkg22\\Msg\\Multi'`

因为第一次`#read`函数调用后使得文件指针指向EOF了。